### PR TITLE
Correct device type annotations

### DIFF
--- a/src/coq2vec/__init__.py
+++ b/src/coq2vec/__init__.py
@@ -349,11 +349,11 @@ class EncoderRNN(nn.Module):
         return output, hidden, cell
 
     @torch.jit.export
-    def initHidden(self,batch_size: int, device: str):
+    def initHidden(self,batch_size: int, device: torch.device):
         return torch.zeros(self.num_layers, batch_size, self.hidden_size, device=device)
 
     @torch.jit.export
-    def initCell(self,batch_size: int, device: str):
+    def initCell(self,batch_size: int, device: torch.device):
         return torch.zeros(self.num_layers, batch_size, self.hidden_size, device=device)
 
 class DecoderRNN(nn.Module):
@@ -375,11 +375,11 @@ class DecoderRNN(nn.Module):
         return token_dist, hidden, cell
 
     @torch.jit.export
-    def initHidden(self,batch_size: int, device: str):
+    def initHidden(self,batch_size: int, device: torch.device):
         return torch.zeros(self.num_layers, batch_size, self.hidden_size, device=device)
 
     @torch.jit.export
-    def initCell(self,batch_size: int, device: str):
+    def initCell(self,batch_size: int, device: torch.device):
         return torch.zeros(self.num_layers, batch_size, self.hidden_size, device=device)
 
 def autoencoderBatchIter(encoder: EncoderRNN, decoder: DecoderRNN, data: torch.LongTensor, output: torch.LongTensor, lengths: torch.LongTensor,


### PR DESCRIPTION
I get the following runtime error with 'str' annotations for the torch devices, which seem to be incorrect. Changing the annotations to the right type fixes the error (see pull request for edits).

```
>>> import coq2vec
>>> import main
/Users/john/.local/share/virtualenvs/coq_proof_difficulty-xnuGSofl/lib/python3.10/site-packages/torch/jit/annotations.py:310: UserWarning: TorchScript will treat type annotations of Tensor dtype-specific subtypes as if they are normal Tensors. dtype constraints are not enforced in compilation either.
  warnings.warn("TorchScript will treat type annotations of Tensor "
>>> main._context_vectorizer
<coq2vec.CoqContextVectorizer object at 0x2897b7a30>
>>> coq2vec.Obligation(["x", "y"], "z")
Obligation(hypotheses=['x', 'y'], goal='z')
>>> ob = coq2vec.Obligation(["x", "y"], "z")
>>> main._context_vectorizer.obligation_to_vector(ob)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/john/.local/share/virtualenvs/coq_proof_difficulty-xnuGSofl/lib/python3.10/site-packages/coq2vec/__init__.py", line 72, in obligation_to_vector
    encoded_goal: torch.Tensor = self.term_encoder.term_to_vector(ob.goal)
  File "/Users/john/.local/share/virtualenvs/coq_proof_difficulty-xnuGSofl/lib/python3.10/site-packages/coq2vec/__init__.py", line 296, in term_to_vector
    return self.seq_to_vector(self.term_to_seq(term_text))
  File "/Users/john/.local/share/virtualenvs/coq_proof_difficulty-xnuGSofl/lib/python3.10/site-packages/coq2vec/__init__.py", line 305, in seq_to_vector
    hidden = self.model.initHidden(1, self.device)
RuntimeError: initHidden() Expected a value of type 'str' for argument 'device' but instead found type 'device'.
Position: 2
Value: device(type='cpu')
Declaration: initHidden(__torch__.coq2vec.EncoderRNN self, int batch_size, str device) -> Tensor
Cast error details: Unable to cast Python instance to C++ type (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)
  ```